### PR TITLE
Properly match INFO and WARN severities.

### DIFF
--- a/lib/fluent/plugin/parser_es_slow_query.rb
+++ b/lib/fluent/plugin/parser_es_slow_query.rb
@@ -1,6 +1,6 @@
 module Fluent
   class ElasticsearchSlowLogParser < Parser
-    REGEXP = /^\[(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\]\[(?<severity>[a-zA-Z]+)\]\[(?<source>\S+)\] \[(?<node>\S+)\] \[(?<index>\w+)\]\[(?<shard>\d+)\] took\[(?<took>.+)\], took_millis\[(?<took_millis>\d+)\], types\[(?<types>.*)\], stats\[(?<stats>.*)\], search_type\[(?<search_type>.*)\], total_shards\[(?<total_shards>\d+)\], source\[(?<source_body>.*)\], extra_source\[(?<extra_source>.*)\]/
+    REGEXP = /^\[(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\]\[(?<severity>[a-zA-Z]+\s*)\]\[(?<source>\S+)\] \[(?<node>\S+)\] \[(?<index>\w+)\]\[(?<shard>\d+)\] took\[(?<took>.+)\], took_millis\[(?<took_millis>\d+)\], types\[(?<types>.*)\], stats\[(?<stats>.*)\], search_type\[(?<search_type>.*)\], total_shards\[(?<total_shards>\d+)\], source\[(?<source_body>.*)\], extra_source\[(?<extra_source>.*)\]/
     TIME_FORMAT = "%Y-%m-%d %H:%M:%S,%N"
 
     Plugin.register_parser("es_slow_query", self)


### PR DESCRIPTION
By default SEVERITY is padded to 5 characters and in case of INFO/WARN
trailing whitespace is added.
